### PR TITLE
Upgrade for Elm 0.17

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Library for integer arithmetic: primes, bases, divisors, gcd...",
     "repository": "https://github.com/lynn/elm-arithmetic.git",
     "license": "BSD3",
@@ -10,7 +10,7 @@
         "Arithmetic"
     ],
     "dependencies": {
-        "elm-lang/core": "3.0.0 <= v < 4.0.0"
+        "elm-lang/core": "4.0.1 <= v < 5.0.0"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/src/Arithmetic.elm
+++ b/src/Arithmetic.elm
@@ -1,4 +1,4 @@
-module Arithmetic
+module Arithmetic exposing
     ( isEven, isOdd
     , toBase, fromBase
     , squareRoot, safeSquareRoot, intSquareRoot, exactIntSquareRoot, isSquare
@@ -7,7 +7,7 @@ module Arithmetic
     , gcd, lcm, isCoprimeTo, totient, extendedGcd
     , powerMod, modularInverse, chineseRemainder
     , isPrime, primesBelow, primeFactors, primeExponents
-    ) where
+    )
 
 {-| A library that provides useful number-theoretical functions for dealing
 with integers, primes, divisibility, et cetera.
@@ -39,7 +39,6 @@ with integers, primes, divisibility, et cetera.
 -}
 
 import Array
-import Graphics.Element exposing (show)
 
 
 {- Parity -}
@@ -84,7 +83,7 @@ toBase base n =
         go n' []
 
 
-{-| Interpret a list of digits as a number in the given base. The input is 
+{-| Interpret a list of digits as a number in the given base. The input is
 expected to consist of integers `d` for which `0 <= d < base`.
 
     fromBase 2 [1, 0, 1, 0, 1, 0] = 42
@@ -288,7 +287,7 @@ lcm a b =
 {-| Test whether two integers are coprime.
 
     56 `isCoprimeTo` 80 == False
-    5 `isCoprimeTo` 8 
+    5 `isCoprimeTo` 8
 -}
 isCoprimeTo : Int -> Int -> Bool
 isCoprimeTo a b =
@@ -427,7 +426,7 @@ chineseRemainder equations =
         (residues, moduli) = List.unzip equations
         m = List.product moduli
         v = List.map (\x -> m // x) moduli
-        
+
         fromJustCons x acc =
             case x of
                 Just y -> Maybe.map ((::) y) acc


### PR DESCRIPTION
- Now using the new `module Arithmetic exposing` syntax
- Removed unused `show` import, which is no longer available in 0.17.
- My editor (Atom) seems to automatically strip out whitespace.
